### PR TITLE
[Feat] slider component 구현

### DIFF
--- a/src/pages/free-font/free-font.tsx
+++ b/src/pages/free-font/free-font.tsx
@@ -1,9 +1,41 @@
+import { useState, useCallback } from 'react';
 import Slider from '@/shared/components/slider/slider';
+
 const FreeFont = () => {
+  // 글자 크기
+  const [fontSize, setFontSize] = useState(30);
+  const handleSizeChange = useCallback((value: number) => {
+    setFontSize(value);
+  }, []);
+
+  // 굵기 개수
+  const [fontWeightNumber, setWeightNumber] = useState(4);
+  const handleFontWeighChange = useCallback((value: number) => {
+    setWeightNumber(value);
+  }, []);
+
   return (
     <div>
-      무료폰트 페이지
-      <Slider label='크기' value='30px' />
+      <h2>무료폰트 페이지</h2>
+
+      <Slider
+        label='크기'
+        valueNumber={fontSize}
+        valueUnit='px'
+        onChange={handleSizeChange}
+      />
+      <div style={{ fontSize: `${fontSize}px` }}>
+        이 텍스트의 크기가 {fontSize}px 입니다.
+      </div>
+
+      <Slider
+        label='굵기 개수'
+        valueNumber={fontWeightNumber}
+        valueUnit='가지'
+        onChange={handleFontWeighChange}
+        min={1}
+        max={9}
+      />
     </div>
   );
 };

--- a/src/pages/free-font/free-font.tsx
+++ b/src/pages/free-font/free-font.tsx
@@ -1,43 +1,5 @@
-import { useState, useCallback } from 'react';
-import Slider from '@/shared/components/slider/slider';
-
 const FreeFont = () => {
-  // 글자 크기
-  const [fontSize, setFontSize] = useState(30);
-  const handleSizeChange = useCallback((value: number) => {
-    setFontSize(value);
-  }, []);
-
-  // 굵기 개수
-  const [fontWeightNumber, setWeightNumber] = useState(4);
-  const handleFontWeighChange = useCallback((value: number) => {
-    setWeightNumber(value);
-  }, []);
-
-  return (
-    <div>
-      <h2>무료폰트 페이지</h2>
-
-      <Slider
-        label='크기'
-        valueNumber={fontSize}
-        valueUnit='px'
-        onChange={handleSizeChange}
-      />
-      <div style={{ fontSize: `${fontSize}px` }}>
-        이 텍스트의 크기가 {fontSize}px 입니다.
-      </div>
-
-      <Slider
-        label='굵기 개수'
-        valueNumber={fontWeightNumber}
-        valueUnit='가지'
-        onChange={handleFontWeighChange}
-        min={1}
-        max={9}
-      />
-    </div>
-  );
+  return <div>무료폰트 페이지</div>;
 };
 
 export default FreeFont;

--- a/src/pages/free-font/free-font.tsx
+++ b/src/pages/free-font/free-font.tsx
@@ -1,5 +1,11 @@
+import Slider from '@/shared/components/slider/slider';
 const FreeFont = () => {
-  return <div>무료폰트 페이지</div>;
+  return (
+    <div>
+      무료폰트 페이지
+      <Slider label='크기' value='30px' />
+    </div>
+  );
 };
 
 export default FreeFont;

--- a/src/shared/components/slider/slider.css.ts
+++ b/src/shared/components/slider/slider.css.ts
@@ -1,10 +1,12 @@
-import { themeVars } from '@/shared/styles';
 import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@/shared/styles';
 
 export const container = style({
   display: 'flex',
   height: '2rem',
   gap: '0.8rem',
+  alignItems: 'center',
 });
 
 export const label = style({
@@ -15,19 +17,18 @@ export const label = style({
 export const sliderContainer = style({
   display: 'flex',
   gap: '0.8rem',
+  alignItems: 'center',
 });
 
 export const slider = style({
   width: '17.5rem',
   selectors: {
-    // 슬라이더 트랙
     '&::-webkit-slider-runnable-track': {
       backgroundColor: themeVars.color.gray_03,
       width: '17.5rem',
       height: '0.1rem',
       borderRadius: '0.1rem',
     },
-    // 슬라이더 핸들
     '&::-webkit-slider-thumb': {
       WebkitAppearance: 'none',
       height: '1.6rem',
@@ -35,11 +36,9 @@ export const slider = style({
       borderRadius: '50%',
       backgroundColor: themeVars.color.primary,
       transition: 'all 0.1s ease-in-out',
-
-      // 슬라이더 핸들이 막대기 중앙에 오도록 위치 조정
+      cursor: 'pointer',
       marginTop: '-0.8rem',
     },
-    // 슬라이더 핸들 호버시
     '&:hover::-webkit-slider-thumb': {
       height: '2rem',
       width: '2rem',
@@ -49,7 +48,6 @@ export const slider = style({
 });
 
 export const value = style({
-  marginTop: '0.1rem',
   ...themeVars.fontStyles.body_14r,
   color: themeVars.color.black,
 });

--- a/src/shared/components/slider/slider.css.ts
+++ b/src/shared/components/slider/slider.css.ts
@@ -3,8 +3,8 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style({
   display: 'flex',
-  gap: '1rem',
-  width: '100%',
+  height: '2rem',
+  gap: '0.8rem',
 });
 
 export const label = style({
@@ -12,14 +12,20 @@ export const label = style({
   color: themeVars.color.black,
 });
 
-export const sliderContainer = style({ display: 'flex', gap: '1rem' });
+export const sliderContainer = style({
+  display: 'flex',
+  gap: '0.8rem',
+});
 
 export const slider = style({
+  width: '17.5rem',
   selectors: {
     // 슬라이더 트랙
     '&::-webkit-slider-runnable-track': {
       backgroundColor: themeVars.color.gray_03,
-      height: '0.2rem',
+      width: '17.5rem',
+      height: '0.1rem',
+      borderRadius: '0.1rem',
     },
     // 슬라이더 핸들
     '&::-webkit-slider-thumb': {
@@ -30,20 +36,20 @@ export const slider = style({
       backgroundColor: themeVars.color.primary,
       transition: 'all 0.1s ease-in-out',
 
-      // 막대기 중앙에 오도록 위치 조정
-      marginTop: '-0.7rem',
+      // 슬라이더 핸들이 막대기 중앙에 오도록 위치 조정
+      marginTop: '-0.8rem',
     },
     // 슬라이더 핸들 호버시
     '&:hover::-webkit-slider-thumb': {
       height: '2rem',
       width: '2rem',
-      marginTop: '-0.9rem',
+      marginTop: '-1rem',
     },
   },
 });
 
 export const value = style({
-  display: 'flex',
+  marginTop: '0.1rem',
   ...themeVars.fontStyles.body_14r,
   color: themeVars.color.black,
 });

--- a/src/shared/components/slider/slider.css.ts
+++ b/src/shared/components/slider/slider.css.ts
@@ -1,0 +1,49 @@
+import { themeVars } from '@/shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  gap: '1rem',
+  width: '100%',
+});
+
+export const label = style({
+  ...themeVars.fontStyles.body_14r,
+  color: themeVars.color.black,
+});
+
+export const sliderContainer = style({ display: 'flex', gap: '1rem' });
+
+export const slider = style({
+  selectors: {
+    // 슬라이더 트랙
+    '&::-webkit-slider-runnable-track': {
+      backgroundColor: themeVars.color.gray_03,
+      height: '0.2rem',
+    },
+    // 슬라이더 핸들
+    '&::-webkit-slider-thumb': {
+      WebkitAppearance: 'none',
+      height: '1.6rem',
+      width: '1.6rem',
+      borderRadius: '50%',
+      backgroundColor: themeVars.color.primary,
+      transition: 'all 0.1s ease-in-out',
+
+      // 막대기 중앙에 오도록 위치 조정
+      marginTop: '-0.7rem',
+    },
+    // 슬라이더 핸들 호버시
+    '&:hover::-webkit-slider-thumb': {
+      height: '2rem',
+      width: '2rem',
+      marginTop: '-0.9rem',
+    },
+  },
+});
+
+export const value = style({
+  display: 'flex',
+  ...themeVars.fontStyles.body_14r,
+  color: themeVars.color.black,
+});

--- a/src/shared/components/slider/slider.tsx
+++ b/src/shared/components/slider/slider.tsx
@@ -3,21 +3,14 @@ import * as styles from './slider.css';
 
 interface SliderProps {
   label: string;
-  valueNumber: number;
-  valueUnit: string;
+  value: number;
+  unit: string;
   onChange: (value: number) => void;
   min?: number;
   max?: number;
 }
 
-const Slider = ({
-  label,
-  valueNumber,
-  valueUnit,
-  onChange,
-  min,
-  max,
-}: SliderProps) => {
+const Slider = ({ label, value, unit, onChange, min, max }: SliderProps) => {
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange(Number(event.target.value));
   };
@@ -29,16 +22,15 @@ const Slider = ({
       <label className={styles.sliderContainer}>
         <input
           className={styles.slider}
-          id='slider_handle'
           type='range'
           min={min}
           max={max}
-          value={valueNumber}
+          value={value}
           onChange={handleChange}
         />
-        <span className={styles.value} id='value'>
-          {valueNumber}
-          {valueUnit}
+        <span className={styles.value}>
+          {value}
+          {unit}
         </span>
       </label>
     </div>

--- a/src/shared/components/slider/slider.tsx
+++ b/src/shared/components/slider/slider.tsx
@@ -1,0 +1,26 @@
+import * as styles from './slider.css';
+
+interface SliderProps {
+  label: string;
+  value: string;
+}
+
+const Slider = ({ label, value }: SliderProps) => {
+  return (
+    <div className={styles.container}>
+      <label className={styles.label}>{label}</label>
+      <label className={styles.sliderContainer}>
+        <input
+          className={styles.slider}
+          type='range'
+          min='0'
+          max='100'
+          defaultValue='20'
+        />
+        <span className={styles.value}>{value}</span>
+      </label>
+    </div>
+  );
+};
+
+export default Slider;

--- a/src/shared/components/slider/slider.tsx
+++ b/src/shared/components/slider/slider.tsx
@@ -1,23 +1,45 @@
+import { type ChangeEvent } from 'react';
 import * as styles from './slider.css';
 
 interface SliderProps {
   label: string;
-  value: string;
+  valueNumber: number;
+  valueUnit: string;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
 }
 
-const Slider = ({ label, value }: SliderProps) => {
+const Slider = ({
+  label,
+  valueNumber,
+  valueUnit,
+  onChange,
+  min,
+  max,
+}: SliderProps) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(Number(event.target.value));
+  };
+
   return (
     <div className={styles.container}>
       <label className={styles.label}>{label}</label>
+
       <label className={styles.sliderContainer}>
         <input
           className={styles.slider}
+          id='slider_handle'
           type='range'
-          min='0'
-          max='100'
-          defaultValue='20'
+          min={min}
+          max={max}
+          value={valueNumber}
+          onChange={handleChange}
         />
-        <span className={styles.value}>{value}</span>
+        <span className={styles.value} id='value'>
+          {valueNumber}
+          {valueUnit}
+        </span>
       </label>
     </div>
   );


### PR DESCRIPTION
## 📌 Summary

> - #32

슬라이더 바를 이용해서 글자 굵기와 크기를 조절할 수 있는 컴포넌트를 구현했습니다. 

## 📚 Tasks

- @src/shared/components/slider 위치에 슬라이더 폴더에서 제작했습니다.
- input type="range"태그 속성을 사용해 슬라이더를 구현했습니다. 
(참고 내용)
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range

## 🔍 Describe

**slider.tsx**

슬라이더의 값들을 props로 받아 상황에 따라 값을 받아 사용할 수 있습니다.
```
interface SliderProps {
  label: string; // 크기 or 굵기 개수
  valueNumber: number; // 값의 넘버타입
  valueUnit: string; // 값의 단위
  onChange: (value: number) => void;
  min?: number; // 슬라이더의 최소값
  max?: number; // 슬라이더의 최대 값
}
```


```
  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
    onChange(Number(event.target.value));
  };
```



`onChange(Number(event.target.value));`
input태그에서 가져오는 `value` 속성의 값은 무조건 문자열로 가져온다고 합니다. 근데 `SliderProps` 에서 슬라이더의 값이 숫자로 처리되어야함으로 Number()함수를 사용해 숫자 타입으로 형변환을 진행합니다.

`(event: ChangeEvent<HTMLInputElement>)` 
합성 이벤트 객체를 매개변수로 받습니다. `ChangeEvent`는 `OnChange` 이벤트를 나타내고 `HTMLInputElementsms` 는 이벤트가 발생한 input요소를 명시합니다. 이 덕분에 typescript는 event.target이 value 속성을 가지고 있는 것을 알 수 있습니다.

</br>

**silder.css.ts**
`className={styles.slider}`는 슬라이더의 트랙`::-webkit-slider-runnable-track`과 핸들`::-webkit-slider-thumb`와 핸들 호버 시 크기가 변하는 인터랙션`&:hover::-webkit-slider-thumb` 일반적인 HTML 요소가 아닌 브라우저의 기본 UI 구성 요소이기에 가상 요소 셀렉터를 사용했습니다. 


</br>

**사용방법**

```
import { useState, useCallback } from 'react';
import Slider from '@/shared/components/slider/slider';

const FreeFont = () => {
  // 글자 크기
  const [fontSize, setFontSize] = useState(30);
  const handleSizeChange = useCallback((value: number) => {
    setFontSize(value);
  }, []);

  // 굵기 개수
  const [fontWeightNumber, setWeightNumber] = useState(4);
  const handleFontWeighChange = useCallback((value: number) => {
    setWeightNumber(value);
  }, []);

  return (
    <div>
      <h2>무료폰트 페이지</h2>

      <Slider
        label='크기'
        valueNumber={fontSize}
        valueUnit='px'
        onChange={handleSizeChange}
      />
      <div style={{ fontSize: `${fontSize}px` }}>
        이 텍스트의 크기가 {fontSize}px 입니다.
      </div>

      <Slider
        label='굵기 개수'
        valueNumber={fontWeightNumber}
        valueUnit='가지'
        onChange={handleFontWeighChange}
        min={1}
        max={9}
      />
    </div>
  );
};
export default FreeFont;
```



## 👀 To Reviewer

- 슬라이더 가로 길이를 17.5rem으로 디자인과 동일하게 맞췄는데 나중에 반응형에 대비해서 `width: ‘100%’` 으로 하는게 나을까요??
- 아래 사진이 `alignItem: ‘center’`로 슬라이더 바랑 양 쪽의 글들이 가운데 정렬을 해도 정렬이 안돼서 양쪽 글에 `marginTop: '0.1rem'` 을 추가해서가운데 맞게 설정했습니다,,,ㅠ 해결방안이 있다면 말씀해주세요ㅠㅠㅠ
<img width="403" height="115" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/901a49e1-7d33-4f89-9249-73a3bfbc3dac" />



## 📸 Screenshot

https://github.com/user-attachments/assets/d68817e3-b2ec-4578-ad80-8c0ef578f97c


